### PR TITLE
fix: call `toLowerCase()` on paths

### DIFF
--- a/pepto-symbol.js
+++ b/pepto-symbol.js
@@ -32,7 +32,7 @@ proxy.on('proxyReq', function(proxyReq, request, response, options) {
 // to S3 with all-lowercase keys, and we lowercase all requests we receive to
 // match.
 proxy.on('proxyReq', function(proxyReq, request, response, options) {
-  proxyReq.path = PATH_PREFIX + proxyReq.path;
+  proxyReq.path = PATH_PREFIX + proxyReq.path.toLowerCase();
 });
 
 http.createServer(function(request, response) {


### PR DESCRIPTION
Turns out the `toLowerCase` is important and we should be lowercasing uploads to S3 instead.